### PR TITLE
Fix: Resolve database permission error in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ RUN mkdir -p logs
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 
+# Create session file and set permissions
+RUN touch /app/telegram_session.session     && chown root:root /app/telegram_session.session
+
 # Run the forwarder
 CMD ["python", "main.py"]


### PR DESCRIPTION
The application was failing to start due to an "unable to open database file" error. This was likely caused by permission issues with the `telegram_session.session` file within the Docker container.

This commit modifies the Dockerfile to:
- Create an empty `telegram_session.session` file in the `/app` directory during the image build process.
- Set the ownership of the `telegram_session.session` file to root, ensuring the application has the necessary permissions to access it.

These changes should resolve the database access issue and allow the application to start correctly.